### PR TITLE
Make sure BrowseView selection doesn't change when switching views in Sidebar

### DIFF
--- a/src/sidebar/BrowseView.js
+++ b/src/sidebar/BrowseView.js
@@ -128,6 +128,7 @@ class BrowseView extends Gtk.ScrolledWindow {
       (item) => item.children,
     );
     this.selection_model = Gtk.SingleSelection.new(this._tree_model);
+    this.selection_model.autoselect = false;
     this.selection_model.connect("selection-changed", () => {
       // If selection changed to sync the sidebar, dont load_uri again
       const uri = this.selection_model.selected_item.item.uri;

--- a/src/sidebar/Sidebar.js
+++ b/src/sidebar/Sidebar.js
@@ -98,7 +98,10 @@ class Sidebar extends Adw.NavigationPage {
         if (!this.search_view.selection_model.n_items)
           this._stack.visible_child = this._status_page;
       } else {
+        const index = this.browse_view.selection_model.selected;
         this._stack.visible_child = this.browse_view;
+        // Make sure the selection doesnt change when switching views
+        this.browse_view.selection_model.selected = index;
       }
     });
   }


### PR DESCRIPTION
Fixes #11

I also set ``autoselect`` to false because I don't think we need it. 