### PR TITLE
Fix initial scrollbar position of sidebar

### DIFF
--- a/src/sidebar/BrowseView.js
+++ b/src/sidebar/BrowseView.js
@@ -198,6 +198,8 @@ class BrowseView extends Gtk.ScrolledWindow {
       });
 
       this.root_model.insert_sorted(page, this.#sortFunc);
+      // Dont move scrollbar while items are being inserted
+      this._adj.value = 0;
     } catch (error) {
       if (!error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
         throw error;


### PR DESCRIPTION
I can set ``this._adj.value`` to 0  after all the items are inserted as well but there's a delay so I'm doing it after every item is added.