### PR TITLE
Scope CSS to the main window

### DIFF
--- a/src/style-dark.css
+++ b/src/style-dark.css
@@ -1,5 +1,5 @@
-window,
-#content-headerbar,
-tabbox {
+.main-window,
+.main-window .content-headerbar,
+.main-window tabbox {
   background-color: #121212;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,6 @@
-window,
-#content-headerbar,
-tabbox {
+.main-window,
+.main-window #content-headerbar,
+.main-window tabbox {
   background-color: #ffffff;
 }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -9,6 +9,8 @@ template $Window: Adw.ApplicationWindow {
   default-width: 1080;
   default-height: 768;
 
+  styles ["main-window"]
+
   Adw.Breakpoint window_breakpoint {
     condition ("max-width: 850sp")
     setters {
@@ -41,7 +43,7 @@ template $Window: Adw.ApplicationWindow {
           Adw.ToolbarView {
             [top]
             Adw.HeaderBar content_header_bar {
-              name: "content-headerbar";
+              styles ["content-headerbar"]
               [start]
               ToggleButton button_sidebar {
                 icon-name: "sidebar-show-symbolic";


### PR DESCRIPTION
Fixes https://github.com/workbenchdev/Biblioteca/issues/43

And use CSS classes instead of CSS ids