### PR TITLE
Fix shortcuts dialog modality

### DIFF
--- a/src/Shortcuts.blp
+++ b/src/Shortcuts.blp
@@ -2,6 +2,7 @@ using Gtk 4.0;
 
 ShortcutsWindow window_shortcuts {
   hide-on-close: true;
+  modal: true;
 
   ShortcutsSection {
     section-name: "shortcuts";


### PR DESCRIPTION
The shortcuts dialog used to not be modal, and this could possibly cause confusion about to which app the shortcuts apply. This pull request fixes this modality issue.