### PR TITLE
Add shortcuts to view open tabs and toggle sidebar

### DIFF
--- a/src/Shortcuts.blp
+++ b/src/Shortcuts.blp
@@ -15,7 +15,7 @@ ShortcutsWindow window_shortcuts {
         accelerator: "<Control>T";
       }
 
-      ShortcutsShortcut {
+        ShortcutsShortcut {
         title: _("Close tab");
         accelerator: "<Control>W";
       }
@@ -38,6 +38,11 @@ ShortcutsWindow window_shortcuts {
       ShortcutsShortcut {
         title: _("Switch to the last tab");
         accelerator: "<Control>End";
+      }
+
+      ShortcutsShortcut {
+        title: _("View all open tabs");
+        accelerator: "<Shift><Control>o";
       }
 
       ShortcutsShortcut {
@@ -116,6 +121,11 @@ ShortcutsWindow window_shortcuts {
 
     ShortcutsGroup {
       title: _("General");
+
+      ShortcutsShortcut {
+        title: _("Show sidebar");
+        accelerator: "F9";
+      }
 
       ShortcutsShortcut {
         title: _("Shortcuts");

--- a/src/Shortcuts.blp
+++ b/src/Shortcuts.blp
@@ -15,7 +15,7 @@ ShortcutsWindow window_shortcuts {
         accelerator: "<Control>T";
       }
 
-        ShortcutsShortcut {
+      ShortcutsShortcut {
         title: _("Close tab");
         accelerator: "<Control>W";
       }

--- a/src/Shortcuts.js
+++ b/src/Shortcuts.js
@@ -13,6 +13,9 @@ export default function Shortcuts(
   zoomOut,
   resetZoom,
   focusGlobalSearch,
+  toggleSidebar,
+  toggleOverview,
+  activateDefault
 ) {
   const { application } = window;
 
@@ -57,6 +60,9 @@ export default function Shortcuts(
     [["<Control>minus", "<Control>underscore"], zoomOut],
     [["<Control>0"], resetZoom],
     [["<Control>K"], focusGlobalSearch],
+    [["F9"], toggleSidebar],
+    [["<Shift><Control>o"], toggleOverview],
+    [["F10"], activateDefault]
   ];
 
   const shortcutController = new Gtk.ShortcutController();

--- a/src/Shortcuts.js
+++ b/src/Shortcuts.js
@@ -15,7 +15,7 @@ export default function Shortcuts(
   focusGlobalSearch,
   toggleSidebar,
   toggleOverview,
-  activateDefault
+  activateDefault // delete when GTK bug with primary menus fixed
 ) {
   const { application } = window;
 
@@ -62,7 +62,7 @@ export default function Shortcuts(
     [["<Control>K"], focusGlobalSearch],
     [["F9"], toggleSidebar],
     [["<Shift><Control>o"], toggleOverview],
-    [["F10"], activateDefault]
+    [["F10"], activateDefault] // delete when GTK bug with primary menus fixed
   ];
 
   const shortcutController = new Gtk.ShortcutController();

--- a/src/Shortcuts.js
+++ b/src/Shortcuts.js
@@ -15,7 +15,6 @@ export default function Shortcuts(
   focusGlobalSearch,
   toggleSidebar,
   toggleOverview,
-  activateDefault // delete when GTK bug with primary menus fixed
 ) {
   const { application } = window;
 
@@ -61,8 +60,7 @@ export default function Shortcuts(
     [["<Control>0"], resetZoom],
     [["<Control>K"], focusGlobalSearch],
     [["F9"], toggleSidebar],
-    [["<Shift><Control>o"], toggleOverview],
-    [["F10"], activateDefault] // delete when GTK bug with primary menus fixed
+    [["<Shift><Control>o"], toggleOverview]
   ];
 
   const shortcutController = new Gtk.ShortcutController();

--- a/src/sidebar/Sidebar.blp
+++ b/src/sidebar/Sidebar.blp
@@ -16,7 +16,7 @@ template $Sidebar : Adw.NavigationPage {
         menu-model: menu_app;
         icon-name: "open-menu-symbolic";
         tooltip-text: _("Main Menu");
-        receives-default: true;
+        receives-default: true; // make primary: true; when GTK bug with primary menus fixed
       }
     }
 

--- a/src/sidebar/Sidebar.blp
+++ b/src/sidebar/Sidebar.blp
@@ -16,7 +16,7 @@ template $Sidebar : Adw.NavigationPage {
         menu-model: menu_app;
         icon-name: "open-menu-symbolic";
         tooltip-text: _("Main Menu");
-        receives-default: true; // make primary: true; when GTK bug with primary menus fixed
+        primary: true;
       }
     }
 

--- a/src/sidebar/Sidebar.blp
+++ b/src/sidebar/Sidebar.blp
@@ -16,7 +16,7 @@ template $Sidebar : Adw.NavigationPage {
         menu-model: menu_app;
         icon-name: "open-menu-symbolic";
         tooltip-text: _("Main Menu");
-        primary: true;
+        receives-default: true;
       }
     }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -9,7 +9,7 @@ template $Window: Adw.ApplicationWindow {
   default-width: 1080;
   default-height: 768;
 
-  styles [ "main-window" ]
+  styles ["main-window"]
 
   Adw.Breakpoint window_breakpoint {
     condition ("max-width: 850sp")
@@ -46,7 +46,7 @@ template $Window: Adw.ApplicationWindow {
           child: Adw.ToolbarView {
             [top]
             Adw.HeaderBar content_header_bar {
-              styles [ "content-headerbar" ]
+              styles ["content-headerbar"]
 
               [start]
               ToggleButton button_sidebar {
@@ -55,7 +55,7 @@ template $Window: Adw.ApplicationWindow {
                 visible: false;
                 active: bind split_view.show-sidebar;
 
-                styles [ "flat" ]
+                styles ["flat"]
               }
 
               [start]
@@ -67,14 +67,14 @@ template $Window: Adw.ApplicationWindow {
                   icon-name: "go-previous-symbolic";
                   tooltip-text: _("Back");
 
-                  styles [ "flat" ]
+                  styles ["flat"]
                 }
 
                 Button button_forward {
                   icon-name: "go-next-symbolic";
                   tooltip-text: _("Forward");
 
-                  styles [ "flat" ]
+                  styles ["flat"]
                 }
               }
 
@@ -85,7 +85,7 @@ template $Window: Adw.ApplicationWindow {
                 action-target: '"file:///app/share/doc/gtk4/index.html"';
                 tooltip-text: _("New Tab");
 
-                styles [ "flat" ]
+                styles ["flat"]
               }
             }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -9,67 +9,84 @@ template $Window: Adw.ApplicationWindow {
   default-width: 1080;
   default-height: 768;
 
-  styles ["main-window"]
+  styles [
+    "main-window"
+  ]
 
   Adw.Breakpoint window_breakpoint {
     condition ("max-width: 850sp")
+
     setters {
       split_view.collapsed: true;
       button_sidebar.visible: true;
     }
   }
 
-  content: Adw.OverlaySplitView split_view {
-    show-sidebar: bind button_sidebar.active;
+  content: Adw.TabOverview tab_overview {
+    enable-new-tab: true;
+    view: tab_view;
 
-    content: Adw.NavigationPage content_page {
-      child: Adw.BreakpointBin {
-        width-request: 360;
-        height-request: 360;
-        Adw.Breakpoint toolbar_breakpoint {
-          condition ("max-width: 450sp")
-          setters {
-            bottom_toolbar.visible: true;
-            button_new_tab.visible: false;
-            tab_bar.visible: false;
-            tab_button.visible: true;
+    Adw.OverlaySplitView split_view {
+      show-sidebar: bind button_sidebar.active;
+
+      content: Adw.NavigationPage content_page {
+        child: Adw.BreakpointBin {
+          width-request: 360;
+          height-request: 360;
+
+          Adw.Breakpoint toolbar_breakpoint {
+            condition ("max-width: 450sp")
+
+            setters {
+              bottom_toolbar.visible: true;
+              button_new_tab.visible: false;
+              tab_bar.visible: false;
+              tab_button.visible: true;
+            }
           }
-        }
 
-        child: Adw.TabOverview tab_overview {
-          enable-new-tab: true;
-          view: tab_view;
-
-          Adw.ToolbarView {
+          child: Adw.ToolbarView {
             [top]
             Adw.HeaderBar content_header_bar {
-              styles ["content-headerbar"]
+              styles [
+                "content-headerbar"
+              ]
+
               [start]
               ToggleButton button_sidebar {
                 icon-name: "sidebar-show-symbolic";
                 tooltip-text: _("Open Sidebar");
                 visible: false;
                 active: bind split_view.show-sidebar;
-                styles ["flat"]
+
+                styles [
+                  "flat"
+                ]
               }
+
               [start]
               Box box_navigation {
                 spacing: 6;
                 halign: start;
+
                 Button button_back {
                   icon-name: "go-previous-symbolic";
                   tooltip-text: _("Back");
-                  styles ["flat"]
+
+                  styles [
+                    "flat"
+                  ]
                 }
 
                 Button button_forward {
                   icon-name: "go-next-symbolic";
                   tooltip-text: _("Forward");
-                  styles ["flat"]
+
+                  styles [
+                    "flat"
+                  ]
                 }
               }
-
-
 
               [end]
               Button button_new_tab {
@@ -77,7 +94,10 @@ template $Window: Adw.ApplicationWindow {
                 action-name: "app.new-tab";
                 action-target: '"file:///app/share/doc/gtk4/index.html"';
                 tooltip-text: _("New Tab");
-                styles ["flat"]
+
+                styles [
+                  "flat"
+                ]
               }
             }
 
@@ -102,9 +122,9 @@ template $Window: Adw.ApplicationWindow {
               vexpand: true;
               shortcuts: all_shortcuts;
             }
-          }
+          };
         };
       };
-    };
+    }
   };
 }

--- a/src/window.blp
+++ b/src/window.blp
@@ -9,9 +9,7 @@ template $Window: Adw.ApplicationWindow {
   default-width: 1080;
   default-height: 768;
 
-  styles [
-    "main-window"
-  ]
+  styles [ "main-window" ]
 
   Adw.Breakpoint window_breakpoint {
     condition ("max-width: 850sp")
@@ -48,9 +46,7 @@ template $Window: Adw.ApplicationWindow {
           child: Adw.ToolbarView {
             [top]
             Adw.HeaderBar content_header_bar {
-              styles [
-                "content-headerbar"
-              ]
+              styles [ "content-headerbar" ]
 
               [start]
               ToggleButton button_sidebar {
@@ -59,9 +55,7 @@ template $Window: Adw.ApplicationWindow {
                 visible: false;
                 active: bind split_view.show-sidebar;
 
-                styles [
-                  "flat"
-                ]
+                styles [ "flat" ]
               }
 
               [start]
@@ -73,18 +67,14 @@ template $Window: Adw.ApplicationWindow {
                   icon-name: "go-previous-symbolic";
                   tooltip-text: _("Back");
 
-                  styles [
-                    "flat"
-                  ]
+                  styles [ "flat" ]
                 }
 
                 Button button_forward {
                   icon-name: "go-next-symbolic";
                   tooltip-text: _("Forward");
 
-                  styles [
-                    "flat"
-                  ]
+                  styles [ "flat" ]
                 }
               }
 
@@ -95,9 +85,7 @@ template $Window: Adw.ApplicationWindow {
                 action-target: '"file:///app/share/doc/gtk4/index.html"';
                 tooltip-text: _("New Tab");
 
-                styles [
-                  "flat"
-                ]
+                styles [ "flat" ]
               }
             }
 

--- a/src/window.js
+++ b/src/window.js
@@ -62,8 +62,7 @@ class Window extends Adw.ApplicationWindow {
       this.resetZoom,
       this.focusGlobalSearch,
       this.toggleSidebar,
-      this.toggleOverview,
-      this.activateDefault // delete when GTK bug with primary menus fixed
+      this.toggleOverview
     );
   }
 
@@ -146,12 +145,6 @@ class Window extends Adw.ApplicationWindow {
 
   toggleOverview = () => {
     this._tab_overview.open = !this._tab_overview.open;
-  }
-
-  // delete when GTK bug with primary menus fixed
-  activateDefault = () => {
-    this._split_view.show_sidebar = true;
-    this._sidebar._button_menu.popup();
   }
 
   #updateWebView = () => {

--- a/src/window.js
+++ b/src/window.js
@@ -63,7 +63,7 @@ class Window extends Adw.ApplicationWindow {
       this.focusGlobalSearch,
       this.toggleSidebar,
       this.toggleOverview,
-      this.activateDefault
+      this.activateDefault // delete when GTK bug with primary menus fixed
     );
   }
 
@@ -148,6 +148,7 @@ class Window extends Adw.ApplicationWindow {
     this._tab_overview.open = !this._tab_overview.open;
   }
 
+  // delete when GTK bug with primary menus fixed
   activateDefault = () => {
     this._split_view.show_sidebar = true;
     this._sidebar._button_menu.popup();

--- a/src/window.js
+++ b/src/window.js
@@ -61,6 +61,9 @@ class Window extends Adw.ApplicationWindow {
       this.zoomOut,
       this.resetZoom,
       this.focusGlobalSearch,
+      this.toggleSidebar,
+      this.toggleOverview,
+      this.activateDefault
     );
   }
 
@@ -95,6 +98,8 @@ class Window extends Adw.ApplicationWindow {
   };
 
   focusGlobalSearch = () => {
+    this._tab_overview.open = false;
+    this._split_view.show_sidebar = true;
     this._sidebar._search_entry.grab_focus();
     this._sidebar._search_entry.select_region(0, -1);
   };
@@ -132,6 +137,21 @@ class Window extends Adw.ApplicationWindow {
     }
     this._tab_view.close_page(this._tab_view.selected_page);
   };
+
+  toggleSidebar = () => {
+    if (this._split_view.collapsed && !this._tab_overview.open) {
+      this._split_view.show_sidebar = !this._split_view.show_sidebar;
+    }
+  }
+
+  toggleOverview = () => {
+    this._tab_overview.open = !this._tab_overview.open;
+  }
+
+  activateDefault = () => {
+    this._split_view.show_sidebar = true;
+    this._sidebar._button_menu.popup();
+  }
 
   #updateWebView = () => {
     this._webview = this._tab_view.selected_page.child;


### PR DESCRIPTION
Fixes all issues listed in #68.

**NOTE**: This pull request removes the marking of the main menu as primary in order to override the activation shortcut of the menu. If this is undesired, I can remove this feature specifically (its code areas are commented to mark how it is a workaround).