### PR TITLE
Add shortcut to focus URL bar

### DIFF
--- a/src/Shortcuts.blp
+++ b/src/Shortcuts.blp
@@ -90,6 +90,11 @@ ShortcutsWindow window_shortcuts {
       }
 
       ShortcutsShortcut {
+        title: _("Focus URL bar");
+        accelerator: "<Control>L";
+      }
+
+      ShortcutsShortcut {
         shortcut-type: gesture_two_finger_swipe_right;
         title: _("Go back to the previous page");
       }

--- a/src/Shortcuts.js
+++ b/src/Shortcuts.js
@@ -13,6 +13,7 @@ export default function Shortcuts(
   zoomOut,
   resetZoom,
   focusGlobalSearch,
+  focusURLBar,
   toggleSidebar,
   toggleOverview,
 ) {
@@ -73,6 +74,7 @@ export default function Shortcuts(
     [["<Control>minus", "<Control>underscore"], zoomOut],
     [["<Control>0"], resetZoom],
     [["<Control>K"], focusGlobalSearch],
+    [["<Control>L"], focusURLBar],
     [["F9"], toggleSidebar],
     [["<Shift><Control>o"], toggleOverview],
   ];

--- a/src/window.js
+++ b/src/window.js
@@ -56,6 +56,7 @@ class Window extends Adw.ApplicationWindow {
       this.zoomOut,
       this.resetZoom,
       this.focusGlobalSearch,
+      this.focusURLBar,
       this.toggleSidebar,
       this.toggleOverview,
     );
@@ -96,6 +97,10 @@ class Window extends Adw.ApplicationWindow {
     this._split_view.show_sidebar = true;
     this._sidebar._search_entry.grab_focus();
     this._sidebar._search_entry.select_region(0, -1);
+  };
+
+  focusURLBar = () => {
+    if (this._webview.is_online) this._url_bar.grab_focus();
   };
 
   newTab = (uri = "file:///app/share/doc/gtk4/index.html") => {


### PR DESCRIPTION
I tried to look into #6 and I still have no clue why those shortcuts don't work. It's weird but the back/forward shortcuts seem to work when the sidebar is in focus, but not when the webview is focus. But the zoom shortcuts always work regardless of what's in focus.