### PR TITLE
Add "devhelp" keyword to desktop file

### DIFF
--- a/data/app.desktop
+++ b/data/app.desktop
@@ -8,6 +8,6 @@ Type=Application
 Categories=Development;GNOME;GTK;
 Icon=@app_id@
 # TRANSLATORS: Don't translate
-Keywords=GTK;libadwaita;doc;documentation;api;manual;
+Keywords=GTK;libadwaita;doc;documentation;api;manual;devhelp;
 DBusActivatable=true
 StartupNotify=true


### PR DESCRIPTION
Biblioteca is basically a replacement for GNOME's Devhelp application, so should be possible to find it using that search term.