### PR TITLE
Find Gtk doc index at build time

### DIFF
--- a/build-aux/build-index.js
+++ b/build-aux/build-index.js
@@ -76,10 +76,17 @@ async function loadDocs() {
   const [pkgdatadir] = ARGV;
   GLib.mkdir_with_parents(pkgdatadir, 0o755);
 
+  const start_index = DOC_INDEX.findIndex((doc) => doc.name === "Gtk-4.0");
+
   await Gio.File.new_for_path(pkgdatadir)
     .get_child("doc-index.json")
     .replace_contents_async(
-      new TextEncoder().encode(JSON.stringify(DOC_INDEX)),
+      new TextEncoder().encode(
+        JSON.stringify({
+          start_index,
+          docs: DOC_INDEX,
+        }),
+      ),
       null,
       false,
       Gio.FileCreateFlags.NONE,

--- a/src/sidebar/Sidebar.blp
+++ b/src/sidebar/Sidebar.blp
@@ -18,6 +18,7 @@ template $Sidebar : Adw.NavigationPage {
     [top]
     Box {
       SearchEntry search_entry {
+        search-delay: 200;
         hexpand: true;
         placeholder-text: _("Search Biblioteca");
       }


### PR DESCRIPTION
The gtk index changed with https://github.com/workbenchdev/Biblioteca/pull/117 and we forgot to update it. It's likely to happen again so instead of a const, let's find the index at build time.