### PR TITLE
metainfo: Use lowercase letters for developer ID

### DIFF
--- a/data/app.metainfo.xml.in
+++ b/data/app.metainfo.xml.in
@@ -3,7 +3,7 @@
   <id>@app_id@</id>
   <launchable type="desktop-id">@app_id@.desktop</launchable>
   <name translatable="no">Biblioteca</name>
-  <developer id="com.github.AkshayWarrier">
+  <developer id="com.github.akshaywarrier">
     <name>Akshay Warrier</name>
   </developer>
   <update_contact>akshaywarrier@gnome.org</update_contact>


### PR DESCRIPTION
This fixes the following warning reported by appstreamcli:
```
W: app.drey.Biblioteca:6: developer-id-invalid com.github.AkshayWarrier
   The developer-ID is invalid. It should be an rDNS string identifying the developer, or a
   Fediverse handle. It must also only contain lowercase ASCII letters, numbers and punctuation.
```