### PR TITLE
Set preferred color scheme later

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -16,6 +16,7 @@ application.connect("activate", () => {
   if (!window) {
     window = new Window({ application });
   }
+  setColorScheme();
   window.open();
 });
 
@@ -25,12 +26,11 @@ application.set_option_context_description(
 
 Actions({ application });
 
-const style_manager = Adw.StyleManager.get_default();
 function setColorScheme() {
+  const style_manager = Adw.StyleManager.get_default();
   const color_scheme = settings.get_int("color-scheme");
   style_manager.set_color_scheme(color_scheme);
 }
-setColorScheme();
 settings.connect("changed::color-scheme", setColorScheme);
 
 export default application;


### PR DESCRIPTION
GTK 4.18 no longer allow to create displays before GDK has been initialized. Therefore the style manager cannot be initialized before that, as it causing an abort.

See details: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7836

Note that Troll is also need to be fixed to be able to launch Biblioteca with GTK 4.18: https://github.com/sonnyp/troll/pull/26