### PR TITLE
Fix passing command-line arguments

### DIFF
--- a/src/biblioteca
+++ b/src/biblioteca
@@ -6,4 +6,4 @@
 # force app in English see https://github.com/workbenchdev/Biblioteca/pull/40#issuecomment-1811380922
 LANG=en_US.UTF-8
 
-@app_id@
+@app_id@ "$@"

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,6 +1,6 @@
 #!@GJS@ -m
 
-import { exit, programArgs } from "system";
+import { exit, programArgs, programInvocationName } from "system";
 import GLib from "gi://GLib";
 import { setConsoleLogDomain } from "console";
 import Xdp from "gi://Xdp";
@@ -29,5 +29,5 @@ if (__DEV__) {
 }
 
 const module = await import("resource:///app/drey/Biblioteca/main.js");
-const exit_code = await module.main(programArgs);
+const exit_code = await module.main([programInvocationName, ...programArgs]);
 exit(exit_code);


### PR DESCRIPTION
The first argument must be the program name.