### PR TITLE
v1.6

### DIFF
--- a/build-aux/app.drey.Biblioteca.Devel.json
+++ b/build-aux/app.drey.Biblioteca.Devel.json
@@ -1,7 +1,7 @@
 {
   "id": "app.drey.Biblioteca.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": ["org.gnome.Sdk.Docs"],
   "command": "biblioteca",

--- a/build-aux/app.drey.Biblioteca.json
+++ b/build-aux/app.drey.Biblioteca.json
@@ -1,7 +1,7 @@
 {
   "id": "app.drey.Biblioteca",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": ["org.gnome.Sdk.Docs"],
   "command": "biblioteca",

--- a/build-aux/modules/blueprint-compiler.json
+++ b/build-aux/modules/blueprint-compiler.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.14.0/blueprint-compiler-v0.14.0.tar.gz",
-      "sha256": "05faf3810cb76d4e2d2382c6a7e6c8096af27e144e2260635c97f6a173d67234"
+      "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/v0.16.0/blueprint-compiler-v0.16.0.tar.gz",
+      "sha256": "01feb8263fe7a450b0a9fed0fd54cf88947aaf00f86cc7da345f8b39a0e7bd30"
     }
   ]
 }

--- a/build-aux/modules/libportal.json
+++ b/build-aux/modules/libportal.json
@@ -15,8 +15,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/flatpak/libportal/releases/download/0.8.1/libportal-0.8.1.tar.xz",
-      "sha256": "281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac"
+      "url": "https://github.com/flatpak/libportal/releases/download/0.9.1/libportal-0.9.1.tar.xz",
+      "sha256": "de801ee349ed3c255a9af3c01b1a401fab5b3fc1c35eb2fd7dfb35d4b8194d7f"
     }
   ]
 }

--- a/build-aux/modules/libshumate.json
+++ b/build-aux/modules/libshumate.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/libshumate/1.3/libshumate-1.3.0.tar.xz",
-      "sha256": "8227a6e8281cde12232894fef83760d44fa66b39ef033c61ed934a86c6dc75d4"
+      "url": "https://download.gnome.org/sources/libshumate/1.4/libshumate-1.4.0.tar.xz",
+      "sha256": "3984368e0259862b3810d1ddc86d2dadd6d372a2b32376ccf4aff7c2e48c6d30"
     }
   ],
   "modules": [

--- a/build-aux/modules/libspelling.json
+++ b/build-aux/modules/libspelling.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/libspelling/0.4/libspelling-0.4.2.tar.xz",
-      "sha256": "b3e609b1a247e71bc097e262564f33f51fd7db566eeb0cd74ae5021536b878b5"
+      "url": "https://download.gnome.org/sources/libspelling/0.4/libspelling-0.4.8.tar.xz",
+      "sha256": "277646285818da7b295ef007b2c5ebd815d0930b3ad097505b3ced96965af517"
     }
   ]
 }

--- a/build-aux/modules/vte.json
+++ b/build-aux/modules/vte.json
@@ -17,8 +17,21 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/vte/0.78/vte-0.78.0.tar.xz",
-      "sha256": "07f09c6228a8bb3c1599dd0f5a6ec797b30d3010c3ac91cf21b69d9635dfaf7c"
+      "url": "https://download.gnome.org/sources/vte/0.80/vte-0.80.1.tar.xz",
+      "sha256": "0cdbd0e983afd9d22e065e323a743160072bf64b453e00b15edbe6f2dcdda46c"
+    }
+  ],
+  "modules": [
+    {
+      "name": "fast_float",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/fastfloat/fast_float/archive/refs/tags/v6.1.6.tar.gz",
+          "sha256": "4458aae4b0eb55717968edda42987cabf5f7fc737aee8fede87a70035dba9ab0"
+        }
+      ]
     }
   ]
 }

--- a/data/app.gschema.xml
+++ b/data/app.gschema.xml
@@ -4,16 +4,16 @@
     <key name="color-scheme" type="i">
       <default>0</default>
     </key>
-    <key name="width" type="i">
+    <key name="window-width" type="i">
       <default>0</default>
     </key>
-    <key name="height" type="i">
+    <key name="window-height" type="i">
       <default>0</default>
     </key>
-    <key name="maximized" type="b">
+    <key name="window-maximized" type="b">
       <default>false</default>
     </key>
-    <key name="fullscreened" type="b">
+    <key name="window-fullscreened" type="b">
       <default>false</default>
     </key>
   </schema>

--- a/data/app.metainfo.xml.in
+++ b/data/app.metainfo.xml.in
@@ -35,6 +35,17 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.6" date="2025-05-06">
+      <description translatable="no">
+        <ul>
+          <li>Update to GNOME 48</li>
+          <li>Update vte to 0.80.1</li>
+          <li>Update libportal to 0.9.1</li>
+          <li>Update libshumate to 1.4.0</li>
+          <li>Update libspelling to 0.4.8</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5" date="2024-10-07">
       <description translatable="no">
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Biblioteca',
-  version: '1.5',
+  version: '1.6',
   meson_version: '>= 0.59.0',
   license: 'GPL-3.0-only'
 )


### PR DESCRIPTION
This PR updates dependencies and prepares for release v1.6.

troll was updated to https://github.com/sonnyp/troll/commit/8b0275948eedec9ed0378f9bdda1aa4aac3062ba. This PR also updates the ``app.gschema`` to use the new window state setting names, as introduced by the change https://github.com/sonnyp/troll/commit/53155a02e06ff66e6c15d470f39d782305c1502f in troll.