### PR TITLE
metainfo: Fix validation

### DIFF
--- a/data/app.metainfo.xml.in
+++ b/data/app.metainfo.xml.in
@@ -102,12 +102,12 @@
     </release>
     <release version="1.1" date="2023-11-12">
       <description translatable="no">
-        Various bug fixes.
+        <p>Various bug fixes.</p>
       </description>
     </release>
     <release version="1.0" date="2023-11-10">
       <description translatable="no">
-        This is the first release of Biblioteca with GNOME 45 documentation. We hope you like it.
+        <p>This is the first release of Biblioteca with GNOME 45 documentation. We hope you like it.</p>
       </description>
     </release>
   </releases>


### PR DESCRIPTION
All text must be in paragraphs or list item elements - text that contained directly in a description element is not permitted.

Reference:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description